### PR TITLE
Add profile page and statistic tracking for users

### DIFF
--- a/data/data_manager.js
+++ b/data/data_manager.js
@@ -81,11 +81,17 @@ export class DataManager{
     }
 
     async archiveBug(id){
-        this.database.modifyBug(id, "archived", true);
+        this.database.modifyBug(id, "archived", true, {
+            statName: "stats.totalArchivedBugs",
+            statInc: 1
+        });
     }
 
     async unarchiveBug(id){
-        this.database.modifyBug(id, "archived", false);
+        this.database.modifyBug(id, "archived", false, {
+            statName: "stats.totalArchivedBugs",
+            statInc: -1
+        });
     }
     
     async deleteProjectInvite(projectId, username){
@@ -93,6 +99,7 @@ export class DataManager{
     }
 
     async deleteBug(id){
+
         return this.database.deleteBug(id);
     }
 

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -1,11 +1,16 @@
 import express from "express";
-import { DataManager } from "../data/data_manager.js";
+import {getDataManager} from "../database.js";
 
 let router = express.Router();
 
 router.get("/", (req, res) => {
-    if (req.isAuthenticated())
-        res.render("profile.ejs", {username: req.user.email});
+    if (req.isAuthenticated()){
+        const db = getDataManager();
+        db.getUser(req.user.email).then(user => {
+            console.log(user);
+            res.render("profile.ejs", {username: req.user.email, userStats: user.stats});
+        });
+    }
     else
         res.redirect("/login");
 });

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -23,11 +23,11 @@
                 <h2>Some Statistics About You!</h2> <hr/>
                 <p>You've done all these great things: </p>
                 <ul style="text-indent: 4ch;">
-                    <li>Created <b>2</b> projects!</li>
-                    <li>Joined <b>0</b> projects!</li>
-                    <li>Created <b>10</b> issues!</li>
-                    <li>Resolved <b>3</b> issues!</li>
-                    <li>Permanently deleted <b>0</b> issues!</li>
+                    <li>Created <b><%=userStats.totalProjectsCreated%></b> projects!</li>
+                    <li>Joined <b><%=userStats.totalJoinedProjects%></b> projects!</li>
+                    <li>Created <b><%=userStats.totalCreatedBugs%></b> issues!</li>
+                    <li>Resolved <b><%=userStats.totalArchivedBugs%></b> issues!</li>
+                    <li>Permanently deleted <b><%=userStats.totalDeletedBugs%></b> issues!</li>
                 </ul>
             </div>
         </main>


### PR DESCRIPTION
The profile page now exists and shows the users email, allows them to change their password (\*_not yet fully supported_), and shows them various statistics about their lifetime on the site. 

The statistics it shows are:
* Total Projects Created
* Total Joined Projects
* Total Created Bugs
* Total Archived Bugs
* Total Deleted Bugs

\* _Requesting to change the password shows a pop up telling the user to check their email for a link to change their password. However no email is sent yet and no link is generated to change their email._